### PR TITLE
Fix SIGMA field mapping for Windows Security Event 4688 false positives

### DIFF
--- a/src/lib/sigma/engine/matcher.ts
+++ b/src/lib/sigma/engine/matcher.ts
@@ -398,6 +398,36 @@ function extractField(event: any, fieldPath: string): any {
     return event[mappedField];
   }
 
+  // SIGMA field name translation: Sysmon -> Windows Security Event Log
+  // Many SIGMA rules use Sysmon field names, but we need to support Windows Security logs too
+  const sigmaFieldMappings: Record<string, string[]> = {
+    // Process Creation (Sysmon EID 1 vs Security EID 4688)
+    'Image': ['NewProcessName'],
+    'ParentImage': ['ParentProcessName'],
+    'CommandLine': ['CommandLine', 'ProcessCommandLine'],
+    'ParentCommandLine': ['ParentProcessCommandLine'],
+    'User': ['SubjectUserName', 'TargetUserName'],
+    'LogonId': ['SubjectLogonId', 'TargetLogonId'],
+    'IntegrityLevel': ['MandatoryLabel'],
+    // File operations
+    'TargetFilename': ['ObjectName'],
+    // Registry operations
+    'TargetObject': ['ObjectName'],
+    // Network
+    'SourceIp': ['IpAddress', 'SourceAddress'],
+    'DestinationIp': ['DestAddress']
+  };
+
+  // Check alternative field names in structured eventData (for WASM-parsed events)
+  const alternativeFields = sigmaFieldMappings[fieldPath];
+  if (alternativeFields && event.eventData) {
+    for (const altField of alternativeFields) {
+      if (altField in event.eventData) {
+        return event.eventData[altField];
+      }
+    }
+  }
+
   // Parse EventData fields from rawLine XML (with caching) - slow path
   if (event.rawLine && typeof event.rawLine === 'string' && event.rawLine.includes('<')) {
     let value = extractFromEventData(event, fieldPath);
@@ -405,27 +435,7 @@ function extractField(event: any, fieldPath: string): any {
       return value;
     }
 
-    // SIGMA field name translation: Sysmon -> Windows Security Event Log
-    // Many SIGMA rules use Sysmon field names, but we need to support Windows Security logs too
-    const sigmaFieldMappings: Record<string, string[]> = {
-      // Process Creation (Sysmon EID 1 vs Security EID 4688)
-      'Image': ['NewProcessName'],
-      'ParentImage': ['ParentProcessName'],
-      'CommandLine': ['CommandLine', 'ProcessCommandLine'],
-      'ParentCommandLine': ['ParentProcessCommandLine'],
-      'User': ['SubjectUserName', 'TargetUserName'],
-      'LogonId': ['SubjectLogonId', 'TargetLogonId'],
-      'IntegrityLevel': ['MandatoryLabel'],
-      // File operations
-      'TargetFilename': ['ObjectName'],
-      // Registry operations
-      'TargetObject': ['ObjectName'],
-      // Network
-      'SourceIp': ['IpAddress', 'SourceAddress'],
-      'DestinationIp': ['DestAddress']
-    };
-
-    const alternativeFields = sigmaFieldMappings[fieldPath];
+    // Check alternative field names via XML parsing (for XML-parsed events)
     if (alternativeFields) {
       for (const altField of alternativeFields) {
         value = extractFromEventData(event, altField);


### PR DESCRIPTION
Fixed false positives in SIGMA rules when analyzing Windows Security Event 4688 logs by ensuring field name mappings (e.g., Image → NewProcessName) are applied to events with structured eventData, not just XML-parsed events.

**Problem**: SIGMA rules like "Execution Of Non-Existing File" and "Execution of Suspicious File Type Extension" were incorrectly matching legitimate processes in Event ID 4688 because:
- Rules check for field "Image" (Sysmon field name)
- Events have "NewProcessName" in eventData (Windows Security field name)
- Field mapping logic was only executed for events with XML in rawLine
- WASM-parsed events have structured eventData but no XML in rawLine
- Field lookup returned undefined, causing negation conditions to trigger false positives

**Root Cause**: In matcher.ts extractField(), the sigmaFieldMappings table was declared inside the XML parsing condition (line 402: `if (event.rawLine.includes('<'))`), so alternative field names were never checked for structured eventData.

**Solution**:
- Moved sigmaFieldMappings declaration outside XML condition
- Added check for alternative fields in event.eventData before XML parsing
- Maintained backward compatibility for XML-parsed events
- Reused same mapping table to avoid duplication

**Changes**:
- src/lib/sigma/engine/matcher.ts: Refactored extractField() to check SIGMA field mappings in both structured eventData and XML parsing paths

**Impact**:
- Fixes false positives for process_creation rules on Event ID 4688
- Improves compatibility between Sysmon-based SIGMA rules and Windows Security logs
- No breaking changes - all existing code paths maintained

**Testing**:
- TypeScript compilation verified (no errors)
- Tested with DE_RDP_Tunnel_5156.evtx sample file
- Verified legitimate processes no longer trigger false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)