### PR TITLE
Fix 'them' keyword in condition patterns

### DIFF
--- a/src/lib/sigma/engine/compiler.ts
+++ b/src/lib/sigma/engine/compiler.ts
@@ -280,7 +280,7 @@ export function validateCompiledRule(compiledRule: CompiledSigmaRule): {
   const referencedSelections = getReferencedSelections(compiledRule.condition);
 
   for (const ref of referencedSelections) {
-    if (!ref.includes('*') && !availableSelections.includes(ref)) {
+    if (!ref.includes('*') && ref.toLowerCase() !== 'them' && !availableSelections.includes(ref)) {
       errors.push(`Selection '${ref}' referenced in condition but not defined`);
     }
   }

--- a/src/lib/sigma/parser/conditionParser.ts
+++ b/src/lib/sigma/parser/conditionParser.ts
@@ -281,8 +281,13 @@ export function getReferencedSelections(condition: ConditionNode): Set<string> {
 /**
  * Expand pattern references to actual selection names
  * e.g., "selection*" matches "selection1", "selection2", etc.
+ * The keyword "them" refers to all defined selections (SIGMA spec).
  */
 export function expandPattern(pattern: string, availableSelections: string[]): string[] {
+  if (pattern.toLowerCase() === 'them') {
+    return [...availableSelections];
+  }
+
   if (!pattern.includes('*')) {
     return [pattern];
   }


### PR DESCRIPTION
'1 of them' / 'all of them' parsed but never matched: expandPattern treated 'them' as a literal selection name, so the condition silently evaluated to false. Per the Sigma spec, 'them' refers to all defined selections.

- expandPattern now expands 'them' to all available selections
- validateCompiledRule no longer flags 'them' as an undefined selection

Fixes GitHub issue re: condition combination support.